### PR TITLE
Remove unused name parameter on upload pages artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          name: my-artifact
           path: ./out
 
   deploy:


### PR DESCRIPTION
Removes the unused `name` parameter on `actions/upload-pages-artifact`